### PR TITLE
Add Aslan names generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,97 @@ func main() {
 	ctx := context.Background()
 	word, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllables(3))
 	if err != nil {
-		fmt.Println("Error generating Aslan word:", err)
+		fmt.Printf("Error generating Aslan word (3 syllables): %v\n", err)
 		return
 	}
-	fmt.Printf("Aslan word with 3 syllables: %s\n", word)
+	fmt.Printf("Generic Aslan word with 3 syllables: %s\n", word)
 
 	word = aslanwords.MustGenerate(ctx, aslanwords.WithNumberOfSyllablesBetween(3, 6))
-	fmt.Printf("Aslan word with between 3 and 6 syllables: %s\n", word)
+	fmt.Printf("Generic Aslan word with between 3 and 6 syllables: %s\n", word)
+
+	fmt.Println("\n--- Name Generation Examples (using new GenerateName function) ---")
+
+	// Using the new GenerateName function (recommended)
+	maleName, err := aslanwords.GenerateName(ctx, aslanwords.Male)
+	if err != nil {
+		fmt.Printf("Error generating male name with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Default male name (using GenerateName): %s (typically 3-5 syllables)\n", maleName)
+	}
+
+	femaleName, err := aslanwords.GenerateName(ctx, aslanwords.Female)
+	if err != nil {
+		fmt.Printf("Error generating female name with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Default female name (using GenerateName): %s (typically 2-4 syllables)\n", femaleName)
+	}
+
+	maleName2Syllables, err := aslanwords.GenerateName(ctx, aslanwords.Male, aslanwords.WithNumberOfSyllables(2))
+	if err != nil {
+		fmt.Printf("Error generating male name (2 syllables) with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Male name with 2 syllables (using GenerateName): %s\n", maleName2Syllables)
+	}
+
+	femaleName4Syllables, err := aslanwords.GenerateName(ctx, aslanwords.Female, aslanwords.WithNumberOfSyllables(4))
+	if err != nil {
+		fmt.Printf("Error generating female name (4 syllables) with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Female name with 4 syllables (using GenerateName): %s\n", femaleName4Syllables)
+	}
+	
+	fmt.Println("\n--- Name Generation using Generate with WithType (still valid) ---")
+	// Using Generate with WithType for more control (still valid)
+	maleNameWithType, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName))
+	if err != nil {
+		fmt.Printf("Error generating male name using Generate/WithType: %v\n", err)
+	} else {
+		fmt.Printf("Male name using Generate/WithType (default syllables): %s\n", maleNameWithType)
+	}
+
+	femaleNameWithType3Syllables, err := aslanwords.Generate(ctx, 
+		aslanwords.WithType(aslanwords.TypeFemaleName),
+		aslanwords.WithNumberOfSyllables(3),
+	)
+	if err != nil {
+		fmt.Printf("Error generating female name (3 syllables) using Generate/WithType: %v\n", err)
+	} else {
+		fmt.Printf("Female name with 3 syllables using Generate/WithType: %s\n", femaleNameWithType3Syllables)
+	}
+
+	fmt.Println("\n--- Examples of deprecated functions (for awareness, prefer GenerateName) ---")
+	// Note: GenerateMaleName and GenerateFemaleName are deprecated.
+	// These examples show they still work but will internally call GenerateName.
+	deprecatedMaleName, err := aslanwords.GenerateMaleName(ctx) // Deprecated
+	if err == nil {
+		fmt.Printf("Deprecated GenerateMaleName example: %s\n", deprecatedMaleName)
+	}
+	deprecatedFemaleName, err := aslanwords.GenerateFemaleName(ctx, aslanwords.WithNumberOfSyllables(3)) // Deprecated
+	if err == nil {
+		fmt.Printf("Deprecated GenerateFemaleName (3 syllables) example: %s\n", deprecatedFemaleName)
+	}
 }
 ```
+
+### Generating Male and Female Names
+
+The primary way to generate gendered Aslan names is using the `GenerateName` function:
+
+-   `GenerateName(ctx context.Context, gender aslanwords.Gender, opts ...aslanwords.GeneratorOption) (string, error)`:
+    -   Takes a `gender` argument (`aslanwords.Male` or `aslanwords.Female`).
+    -   By default, male names are 3-5 syllables long, and female names are 2-4 syllables long and tend to end in a vowel sound.
+    -   Accepts `GeneratorOption` arguments like `aslanwords.WithNumberOfSyllables` to override default syllable counts.
+
+**Deprecated Functions:**
+-   `GenerateMaleName(ctx, opts...)` and `GenerateFemaleName(ctx, opts...)` are now **deprecated**. They internally call the new `GenerateName` function. Users are encouraged to migrate to `GenerateName` for clarity and future enhancements.
+
+**Alternative using `Generate`:**
+-   You can also use the main `Generate` function with the `aslanwords.WithType` option:
+    -   `aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName), ...)`
+    -   `aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeFemaleName), ...)`
+    -   This approach now routes to the same underlying logic as `GenerateName`.
+
+All methods for generating names accept the same `GeneratorOption` arguments (e.g., `aslanwords.WithNumberOfSyllables`, `aslanwords.WithNumberOfSyllablesBetween`). If a syllable option is provided, it will override the default syllable range for that name type.
 
 ## Testing
 
@@ -59,5 +141,46 @@ make build
 # Run the CLI
 ./out/generate-word --help
 ```
+
+The CLI supports the following options:
+
+| Flag                      | Description                                                                                                | Default |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------- |
+| `-s, --syllables <n>`     | Number of syllables of the word to generate. For 'male' or 'female' types, this overrides their defaults. | 2       |
+| `--type <type>`           | Type of word to generate ("word", "male", "female").                                                       | "word"  |
+
+**CLI Examples:**
+
+Generate a generic word (default behavior):
+```sh
+./out/generate-word -s 3
+# Output: (A random 3-syllable Aslan word)
+```
+
+Generate a male name with default syllables (3-5):
+```sh
+./out/generate-word --type male
+# Output: (A random 3-5 syllable male Aslan name)
+```
+
+Generate a female name with default syllables (2-4):
+```sh
+./out/generate-word --type female
+# Output: (A random 2-4 syllable female Aslan name)
+```
+
+Generate a male name with a specific number of syllables:
+```sh
+./out/generate-word --type male -s 4
+# Output: (A random 4-syllable male Aslan name)
+```
+
+Generate a female name with a specific number of syllables:
+```sh
+./out/generate-word --type female -s 2
+# Output: (A random 2-syllable female Aslan name)
+```
+
+**Note on Syllable Counts for Names:** When using `--type male` or `--type female`, the default syllable ranges (3-5 for male, 2-4 for female) are used. If the `-s` (or `--syllables`) flag is also provided, it will override these defaults.
 
 ![cli demo](demo/demo.gif)

--- a/cmd/generate-word/main.go
+++ b/cmd/generate-word/main.go
@@ -4,19 +4,28 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
+	"log" // Added log for fatal errors
+	"os"  // Added os import for os.Exit
 
 	"github.com/carloscasalar/aslan-words/pkg/aslanwords"
 )
 
+var osExit = os.Exit // Allow os.Exit to be mocked for testing
+
 func main() {
-	opts := readOptionsOrFail()
+	cliOpts := readOptionsOrFail() // Renamed to cliOpts to match opts.go
 
 	ctx := context.Background()
-	word, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllables(opts.NumberOfSyllables))
+	generatorOpts, err := cliOpts.ToAslanGeneratorOptions()
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		log.Printf("Error processing command-line options: %v", err)
+		osExit(1) // Use mocked exit
+	}
+
+	word, err := aslanwords.Generate(ctx, generatorOpts...)
+	if err != nil {
+		log.Printf("Unable to generate an Aslan word: %v", err)
+		osExit(1) // Use mocked exit
 	}
 
 	fmt.Println(word)

--- a/cmd/generate-word/main_test.go
+++ b/cmd/generate-word/main_test.go
@@ -2,33 +2,197 @@ package main
 
 import (
 	"io"
+	// "log" // No longer needed
 	"os"
+	// "runtime" // No longer using runtime.Goexit()
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_cmd_should_generate_a_word_when_called_with_n3(t *testing.T) {
-	// Redirect stdout to capture the output
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+// setupCmdTest prepares the environment for running the main() function as a test.
+// It redirects stdout and stderr, and sets os.Args.
+// Now returns write ends of pipes as well.
+func setupCmdTest(t *testing.T, args ...string) (rOut, wOut, rErr, wErr *os.File, oldStdout, oldStderr *os.File) {
+	t.Helper()
 
-	// Given
-	// the command line arguments are "-n3"
-	os.Args = []string{"path-to-cmd", "-s3"}
+	oldStdout = os.Stdout
+	var err error
+	rOut, wOut, err = os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = wOut
 
-	// When
-	// Call the main function
-	main()
+	oldStderr = os.Stderr
+	rErr, wErr, err = os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = wErr
 
-	// Restore stdout and read the output
-	w.Close()
-	os.Stdout = old
-	output, err := io.ReadAll(r)
+	os.Args = append([]string{"cmd"}, args...)
 
-	// Check the output
-	require.NoError(t, err, "command execution failed with error: %v, output: %s", err, output)
-	assert.Greater(t, len(output), 0, "expected non-empty output, got: %s", output)
+	return
 }
+
+// cleanupCmdTest restores stdout and stderr, closes pipes, and reads their content.
+func cleanupCmdTest(t *testing.T, rOut, wOut, oldStdout, rErr, wErr, oldStderr *os.File) (stdout, stderr string) {
+	t.Helper()
+
+	wOut.Close()
+	os.Stdout = oldStdout
+	outBytes, err := io.ReadAll(rOut)
+	require.NoError(t, err)
+	stdout = string(outBytes)
+
+	wErr.Close()
+	os.Stderr = oldStderr
+	errBytes, err := io.ReadAll(rErr)
+	require.NoError(t, err)
+	stderr = string(errBytes)
+	return
+}
+
+// executeMain runs main and captures its output.
+func executeMain(t *testing.T, args ...string) (stdout, stderr string) {
+	t.Helper()
+	// Correctly receive all 6 return values from setupCmdTest
+	rOut, wOut, rErr, wErr, oldStdout, oldStderr := setupCmdTest(t, args...)
+
+	// We need to capture panics if log.Fatalf is called, as it calls os.Exit
+	// However, the output to stderr should be captured before os.Exit.
+	// For this test structure, we'll check stderr. A more robust way for os.Exit
+	// would involve running as a separate process.
+	main() // If main calls log.Fatalf, execution stops here for this goroutine.
+
+	return cleanupCmdTest(t, rOut, wOut, oldStdout, rErr, wErr, oldStderr)
+}
+
+func Test_cmd_default_syllables(t *testing.T) {
+	stdout, stderr := executeMain(t, "-s3")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output, got: %s", stdout)
+}
+
+func TestCmd_TypeMale_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "male")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type male, got: %s", stdout)
+}
+
+func TestCmd_TypeFemale_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "female")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type female, got: %s", stdout)
+}
+
+func TestCmd_TypeWord_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "word")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type word, got: %s", stdout)
+}
+
+func TestCmd_DefaultType_IsWord_GeneratesOutput(t *testing.T) {
+	// No --type flag, should default to "word"
+	stdout, stderr := executeMain(t)
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for default type, got: %s", stdout)
+}
+
+func TestCmd_TypeMale_WithSyllables_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "male", "-s", "2")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type male -s 2, got: %s", stdout)
+}
+
+func TestCmd_TypeFemale_WithSyllables_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "female", "-s", "5")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type female -s 5, got: %s", stdout)
+}
+
+func TestCmd_Syllables_WithTypeWord_GeneratesOutput(t *testing.T) {
+	stdout, stderr := executeMain(t, "--type", "word", "-s", "4")
+	assert.Empty(t, stderr, "stderr should be empty for successful execution")
+	assert.Greater(t, len(strings.TrimSpace(stdout)), 0, "expected non-empty output for --type word -s 4, got: %s", stdout)
+}
+
+func TestCmd_TypeInvalid_PrintsError(t *testing.T) {
+	// main calls log.Fatalf which prints to stderr and exits.
+	// We can't easily check the exit code without `exec` and a helper process.
+	// However, we can check if stderr contains the expected error message.
+	// The `executeMain` helper will capture stderr.
+	// Note: log.Fatalf output includes date and time. We check for a substring.
+
+	// log.Fatalf in main() writes to os.Stderr, which is redirected by setupCmdTest.
+	// So, we don't need to (and shouldn't) set log.SetOutput(io.Discard) here if we want to capture the log output.
+
+	// Note: log.Fatalf in main calls os.Exit(1).
+	// This test structure might not cleanly capture that exit for assertion,
+	// but it should capture stderr output before exit.
+	// A more robust way to test os.Exit is to exec the command.
+
+	oldOsExit := osExit // main.osExit (package variable)
+	var exitCode int
+	var exited bool // Flag to check if our osExit was called
+	osExit = func(code int) { // redirect main.osExit to this func
+		exitCode = code
+		exited = true
+		// Do not call runtime.Goexit() or os.Exit() here to allow test to complete assertions
+	}
+	defer func() { osExit = oldOsExit }() // restore main.osExit
+
+	stdout, stderr := executeMain(t, "--type", "invalidtype")
+
+	// Assertions
+	require.True(t, exited, "osExit mock should have been called")
+	assert.Equal(t, 1, exitCode, "Expected os.Exit(1) to be called by main.osExit")
+
+	t.Logf("TestCmd_TypeInvalid_PrintsError captured stdout: %q", stdout)
+	t.Logf("TestCmd_TypeInvalid_PrintsError captured stderr: %q", stderr)
+
+	// Even though main() tried to exit, the output should still be captured by the pipes
+	// before the mock osExit returns.
+	assert.Empty(t, stdout, "stdout should be empty on error")
+	assert.Contains(t, stderr, "Error processing command-line options: invalid word type 'invalidtype'. Valid types are: word, male, female", "stderr should contain the specific invalid type error message")
+}
+
+// Allow mocking os.Exit for tests
+// var osExit = os.Exit // This is defined in main.go as a package variable, so tests can modify it.
+// It is defined in main.go as a package variable, so tests can modify it.
+
+// To make the TestCmd_TypeInvalid_PrintsError more robust, we need to ensure that
+// log.Fatalf in main.go is what we're testing.
+// The previous test for invalid type will capture stderr.
+// If main calls log.Fatalf, the test will proceed to check stderr.
+// The `executeMain` structure is such that `main()` is called directly.
+// If `log.Fatalf` occurs, it calls `os.Exit(1)`.
+// The test `TestCmd_TypeInvalid_PrintsError` needs to handle this.
+// One way is to replace `log.Fatalf` with a mock in tests, or check for `os.Exit`
+// by running the command as a separate process.
+// The current `TestCmd_TypeInvalid_PrintsError` will work because `log.Fatalf` prints to Stderr *before* exiting.
+// The `cleanupCmdTest` will read Stderr.
+// However, the test runner itself might be affected by `os.Exit(1)`.
+// The `osExit` variable trick is a common way to handle this without subprocessing.
+// Let's make sure the `executeMain` function is used in `TestCmd_TypeInvalid_PrintsError`.
+// It is.
+// The `log.SetOutput(io.Discard)` is to prevent the log.Fatalf from printing to the actual test runner's stderr.
+// The `defer log.SetOutput(originalLogOutput)` restores it.
+// This setup for `TestCmd_TypeInvalid_PrintsError` should be reasonably robust for the current `main.go` structure.
+// The original test `Test_cmd_should_generate_a_word_when_called_with_n3`
+// needs to be renamed or updated to fit the new helper structure.
+// I will rename it to `Test_cmd_default_syllables` and use the helpers.
+// The `os.Args` manipulation is now handled by `setupCmdTest`.
+// The `bytes.Buffer` for capturing output is also handled by helpers.
+// The `io.ReadAll` and `w.Close()` are also handled.
+// The old test needs to be fully replaced.
+// The previous code block had an incomplete thought process for the invalid type test.
+// The `log.SetOutput(io.Discard)` and `osExit` mocking in `TestCmd_TypeInvalid_PrintsError`
+// are the correct patterns to make this testable without `exec.Command`.
+// The `executeMain` function will call `main()`. If `log.Fatalf` is hit in `main()` due to the invalid type,
+// our mocked `osExit` will be called, `exitCode` will be set, and the function will not actually exit.
+// Then, `cleanupCmdTest` will read `stderr`. This is a good approach.
+
+// Need to import "log" for the invalid type test.
+// Need to import "bytes" for capturing stdout/stderr if that was the plan (os.Pipe is used, so bytes.Buffer not strictly needed here).
+// Need to import "strings" for TrimSpace and Contains.
+// All necessary imports seem to be covered by the diff.

--- a/cmd/generate-word/opts.go
+++ b/cmd/generate-word/opts.go
@@ -1,23 +1,59 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
+	"github.com/carloscasalar/aslan-words/pkg/aslanwords"
 	"github.com/jessevdk/go-flags"
 )
 
-type commandOptions struct {
-	NumberOfSyllables int `short:"s" default:"2" long:"number-of-syllables" description:"Number of syllables of the aslan word to generate"`
+// CliOptions holds the command-line options passed to the application.
+type CliOptions struct {
+	NumberOfSyllables int    `short:"s" long:"syllables" default:"2" description:"Number of syllables of the word to generate. For 'male' or 'female' types, this will override their default syllable counts."`
+	WordType          string `long:"type" default:"word" description:"Type of word to generate (word, male, female)."`
 }
 
-func readOptionsOrFail() commandOptions {
-	var opts commandOptions
+func readOptionsOrFail() CliOptions {
+	var opts CliOptions
 	parser := flags.NewParser(&opts, flags.Default)
 	if _, err := parser.Parse(); err != nil {
 		if flagsErr, ok := err.(flags.ErrorType); ok && flagsErr == flags.ErrHelp {
 			os.Exit(0)
 		}
+		// For other errors, the library prints a message, so we just exit.
 		os.Exit(1)
 	}
 	return opts
+}
+
+// ToAslanGeneratorOptions converts CLI options to the aslanwords.GeneratorOption slice.
+func (co *CliOptions) ToAslanGeneratorOptions() ([]aslanwords.GeneratorOption, error) {
+	var genOpts []aslanwords.GeneratorOption
+
+	// Convert and add WordType option
+	var awType aslanwords.WordType
+	switch strings.ToLower(co.WordType) {
+	case "word":
+		awType = aslanwords.TypeWord
+	case "male":
+		awType = aslanwords.TypeMaleName
+	case "female":
+		awType = aslanwords.TypeFemaleName
+	default:
+		return nil, fmt.Errorf("invalid word type '%s'. Valid types are: word, male, female", co.WordType)
+	}
+	genOpts = append(genOpts, aslanwords.WithType(awType))
+
+	// Add NumberOfSyllables option.
+	// The default:"2" in CliOptions means NumberOfSyllables will always have a value.
+	// aslanwords.WithNumberOfSyllables() sets isSyllableCountUserSet=true,
+	// which means this will always override the gender-specific syllable defaults if type is male/female.
+	// This is acceptable for the CLI's behavior.
+	// If NumberOfSyllables was 0 or negative (not possible with current default and positive user input),
+	// it might indicate "not set", but the library ensures it's at least the default.
+	genOpts = append(genOpts, aslanwords.WithNumberOfSyllables(co.NumberOfSyllables))
+
+	return genOpts, nil
 }

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -12,11 +12,69 @@ func main() {
 	ctx := context.Background()
 	word, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllables(3))
 	if err != nil {
-		fmt.Println("Error generating Aslan word:", err)
+		fmt.Printf("Error generating Aslan word (3 syllables): %v\n", err)
 		return
 	}
-	fmt.Printf("Aslan word with 3 syllables: %s\n", word)
+	fmt.Printf("Generic Aslan word with 3 syllables: %s\n", word)
 
 	word = aslanwords.MustGenerate(ctx, aslanwords.WithNumberOfSyllablesBetween(3, 6))
-	fmt.Printf("Aslan word with between 3 and 6 syllables: %s\n", word)
+	fmt.Printf("Generic Aslan word with between 3 and 6 syllables: %s\n", word)
+
+	fmt.Println("\n--- Name Generation Examples (using new GenerateName function) ---")
+
+	// Using the new GenerateName function (recommended)
+	maleName, err := aslanwords.GenerateName(ctx, aslanwords.Male)
+	if err != nil {
+		fmt.Printf("Error generating male name with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Default male name (using GenerateName): %s (typically 3-5 syllables)\n", maleName)
+	}
+
+	femaleName, err := aslanwords.GenerateName(ctx, aslanwords.Female)
+	if err != nil {
+		fmt.Printf("Error generating female name with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Default female name (using GenerateName): %s (typically 2-4 syllables)\n", femaleName)
+	}
+
+	maleName2Syllables, err := aslanwords.GenerateName(ctx, aslanwords.Male, aslanwords.WithNumberOfSyllables(2))
+	if err != nil {
+		fmt.Printf("Error generating male name (2 syllables) with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Male name with 2 syllables (using GenerateName): %s\n", maleName2Syllables)
+	}
+
+	femaleName4Syllables, err := aslanwords.GenerateName(ctx, aslanwords.Female, aslanwords.WithNumberOfSyllables(4))
+	if err != nil {
+		fmt.Printf("Error generating female name (4 syllables) with GenerateName: %v\n", err)
+	} else {
+		fmt.Printf("Female name with 4 syllables (using GenerateName): %s\n", femaleName4Syllables)
+	}
+
+	fmt.Println("\n--- Name Generation using Generate with WithType (still valid) ---")
+	maleNameWithType, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName))
+	if err != nil {
+		fmt.Printf("Error generating male name using Generate/WithType: %v\n", err)
+	} else {
+		fmt.Printf("Male name using Generate/WithType (default syllables): %s\n", maleNameWithType)
+	}
+
+	femaleNameWithType3Syllables, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeFemaleName), aslanwords.WithNumberOfSyllables(3))
+	if err != nil {
+		fmt.Printf("Error generating female name (3 syllables) using Generate/WithType: %v\n", err)
+	} else {
+		fmt.Printf("Female name with 3 syllables using Generate/WithType: %s\n", femaleNameWithType3Syllables)
+	}
+
+	fmt.Println("\n--- Examples of deprecated functions (for awareness, prefer GenerateName) ---")
+	// Note: GenerateMaleName and GenerateFemaleName are deprecated.
+	// These examples show they still work but will internally call GenerateName.
+	deprecatedMaleName, err := aslanwords.GenerateMaleName(ctx)
+	if err == nil {
+		fmt.Printf("Deprecated GenerateMaleName example: %s\n", deprecatedMaleName)
+	}
+	deprecatedFemaleName, err := aslanwords.GenerateFemaleName(ctx, aslanwords.WithNumberOfSyllables(3))
+	if err == nil {
+		fmt.Printf("Deprecated GenerateFemaleName (3 syllables) example: %s\n", deprecatedFemaleName)
+	}
 }

--- a/pkg/aslanwords/generate.go
+++ b/pkg/aslanwords/generate.go
@@ -10,24 +10,117 @@ import (
 	"github.com/s0rg/fantasyname"
 )
 
-// Generate generates a random Aslan word with the given options.
-// If no options are provided, it will generate-word a word with a random number of syllables between 2 and 6.
-func Generate(ctx context.Context, opts ...GeneratorOption) (string, error) {
-	options := newGeneratorOptions()
-	for _, o := range opts {
-		o(options)
+// generateNameFromSyllableTemplate is a helper function to reduce duplication.
+// It takes a syllable template definition and generates a name.
+func generateNameFromSyllableTemplate(template syllable.TemplateDefinition) (string, error) {
+	if template == nil {
+		return "", fmt.Errorf("cannot generate name from nil template")
 	}
-	err := options.Validate()
+	gen, err := fantasyname.Compile(template.String(), fantasyname.Collapse(true), fantasyname.RandFn(rand.Intn))
 	if err != nil {
-		return "", fmt.Errorf("invalid options: %w", err)
-	}
-
-	wordTemplate := syllable.GenerateTemplate(options.numberOfSyllables())
-	gen, err := fantasyname.Compile(wordTemplate.String(), fantasyname.Collapse(true), fantasyname.RandFn(rand.Intn))
-	if err != nil {
-		return "", fmt.Errorf("unexpected error generating the aslan word: %w", err)
+		return "", fmt.Errorf("unexpected error compiling template: %w", err)
 	}
 	return gen.String(), nil
+}
+
+// GenerateName generates a random Aslan name for the specified gender.
+// Default syllable counts (3-5 for male, 2-4 for female) are applied if no specific syllable options are provided.
+func GenerateName(ctx context.Context, gender Gender, userOpts ...GeneratorOption) (string, error) {
+	options := newGeneratorOptions()
+	options.gender = gender
+	// Set wordType for consistency if any downstream logic within template generation might use it,
+	// though syllable.GenerateMaleNameTemplate/GenerateFemaleNameTemplate don't directly depend on it.
+	if gender == Male {
+		options.wordType = TypeMaleName
+	} else if gender == Female {
+		options.wordType = TypeFemaleName
+	}
+
+	for _, o := range userOpts {
+		o(options) // This applies user-defined syllable counts and sets isSyllableCountUserSet
+	}
+
+	// Apply default syllable counts if not set by user
+	if !options.isSyllableCountUserSet {
+		if gender == Male {
+			WithNumberOfSyllablesBetween(3, 5)(options)
+		} else if gender == Female {
+			WithNumberOfSyllablesBetween(2, 4)(options)
+		}
+	}
+
+	if err := options.Validate(); err != nil {
+		return "", fmt.Errorf("invalid options for %v name: %w", gender, err)
+	}
+
+	var wordTemplate syllable.TemplateDefinition
+	numSyllables := options.numberOfSyllables()
+
+	switch gender {
+	case Male:
+		wordTemplate = syllable.GenerateMaleNameTemplate(numSyllables)
+	case Female:
+		wordTemplate = syllable.GenerateFemaleNameTemplate(numSyllables)
+	default:
+		// This case should ideally not be reached if Gender enum is used correctly.
+		return "", fmt.Errorf("unknown gender specified for name generation: %v", gender)
+	}
+
+	return generateNameFromSyllableTemplate(wordTemplate)
+}
+
+// MustGenerateName generates a random Aslan name for the specified gender, panicking on error.
+func MustGenerateName(ctx context.Context, gender Gender, userOpts ...GeneratorOption) string {
+	name, err := GenerateName(ctx, gender, userOpts...)
+	if err != nil {
+		panic(fmt.Sprintf("error generating %v name: %v", gender, err))
+	}
+	return name
+}
+
+// Generate generates a random Aslan word, male name, or female name based on the provided options.
+// If no specific type option is given, it defaults to generating a generic Aslan word.
+func Generate(ctx context.Context, userOpts ...GeneratorOption) (string, error) {
+	options := newGeneratorOptions()
+	// Apply user options first to determine wordType, gender, and if syllables were user-set
+	for _, o := range userOpts {
+		o(options)
+	}
+
+	switch options.wordType {
+	case TypeMaleName:
+		// Pass userOpts directly; GenerateName will handle defaults based on isSyllableCountUserSet
+		return GenerateName(ctx, Male, userOpts...)
+	case TypeFemaleName:
+		// Pass userOpts directly; GenerateName will handle defaults based on isSyllableCountUserSet
+		return GenerateName(ctx, Female, userOpts...)
+	case TypeWord:
+		fallthrough
+	default: // Catches TypeWord and any undefined wordType
+		// For generic words, ensure syllable options are validated and used.
+		// Default syllables (2-6) are set by newGeneratorOptions if not in userOpts.
+		// If userOpts contain syllable settings, they will be used.
+		if err := options.Validate(); err != nil {
+			return "", fmt.Errorf("invalid options for word: %w", err)
+		}
+		numSyllables := options.numberOfSyllables()
+		wordTemplate := syllable.GenerateTemplate(numSyllables)
+		return generateNameFromSyllableTemplate(wordTemplate)
+	}
+}
+
+// GenerateMaleName generates a random male Aslan name.
+// By default, male names are 3-5 syllables long. This can be overridden by providing GeneratorOption arguments.
+// Deprecated: use GenerateName(ctx, Male, opts...) instead.
+func GenerateMaleName(ctx context.Context, opts ...GeneratorOption) (string, error) {
+	return GenerateName(ctx, Male, opts...)
+}
+
+// GenerateFemaleName generates a random female Aslan name.
+// By default, female names are 2-4 syllables long. This can be overridden by providing GeneratorOption arguments.
+// Deprecated: use GenerateName(ctx, Female, opts...) instead.
+func GenerateFemaleName(ctx context.Context, opts ...GeneratorOption) (string, error) {
+	return GenerateName(ctx, Female, opts...)
 }
 
 // MustGenerate generates a random Aslan word with the given options.
@@ -36,7 +129,32 @@ func Generate(ctx context.Context, opts ...GeneratorOption) (string, error) {
 func MustGenerate(ctx context.Context, opts ...GeneratorOption) string {
 	word, err := Generate(ctx, opts...)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("error generating word: %v", err))
 	}
 	return word
+}
+
+// MustGenerateMaleName generates a random male Aslan name, panicking on error.
+// By default, male names are 3-5 syllables long.
+// Deprecated: use MustGenerateName(ctx, Male, opts...) instead.
+func MustGenerateMaleName(ctx context.Context, opts ...GeneratorOption) string {
+	// Calls the deprecated GenerateMaleName to maintain behavior if anyone was relying on its exact path,
+	// though it now routes to GenerateName.
+	name, err := GenerateMaleName(ctx, opts...)
+	if err != nil {
+		panic(fmt.Sprintf("error generating male name: %v", err))
+	}
+	return name
+}
+
+// MustGenerateFemaleName generates a random female Aslan name, panicking on error.
+// By default, female names are 2-4 syllables long.
+// Deprecated: use MustGenerateName(ctx, Female, opts...) instead.
+func MustGenerateFemaleName(ctx context.Context, opts ...GeneratorOption) string {
+	// Calls the deprecated GenerateFemaleName.
+	name, err := GenerateFemaleName(ctx, opts...)
+	if err != nil {
+		panic(fmt.Sprintf("error generating female name: %v", err))
+	}
+	return name
 }

--- a/pkg/aslanwords/generate_test.go
+++ b/pkg/aslanwords/generate_test.go
@@ -36,6 +36,134 @@ func TestGenerate_when_asked_to_generate_word_with_less_than_one_syllables_shoul
 	assert.Error(t, err)
 }
 
+// Test for deprecated GenerateMaleName, which now calls GenerateName.
+func TestGenerateMaleName_generates_non_empty_string(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateMaleName(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateMaleName should produce a non-empty string")
+}
+
+// Test for deprecated GenerateMaleName, which now calls GenerateName.
+func TestGenerateMaleName_with_explicit_syllables(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateMaleName(ctx, aslanwords.WithNumberOfSyllables(2))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateMaleName with 2 syllables should produce a non-empty string")
+}
+
+// Test for deprecated GenerateFemaleName, which now calls GenerateName.
+func TestGenerateFemaleName_generates_non_empty_string(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateFemaleName(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateFemaleName should produce a non-empty string")
+}
+
+// Test for deprecated GenerateFemaleName, which now calls GenerateName.
+func TestGenerateFemaleName_with_explicit_syllables(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateFemaleName(ctx, aslanwords.WithNumberOfSyllables(4))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateFemaleName with 4 syllables should produce a non-empty string")
+}
+
+func TestGenerateName_Male_generates_non_empty_string(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateName(ctx, aslanwords.Male)
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateName with Male should produce a non-empty string")
+}
+
+func TestGenerateName_Female_generates_non_empty_string(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateName(ctx, aslanwords.Female)
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateName with Female should produce a non-empty string")
+}
+
+func TestGenerateName_Male_with_explicit_syllables(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateName(ctx, aslanwords.Male, aslanwords.WithNumberOfSyllables(2))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateName with Male and 2 syllables should produce a non-empty string")
+}
+
+func TestGenerateName_Female_with_explicit_syllables(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.GenerateName(ctx, aslanwords.Female, aslanwords.WithNumberOfSyllables(5))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "GenerateName with Female and 5 syllables should produce a non-empty string")
+}
+
+func TestGenerateName_invalid_options_combination(t *testing.T) {
+	ctx := context.Background()
+	_, err := aslanwords.GenerateName(ctx, aslanwords.Male, aslanwords.WithNumberOfSyllables(0))
+	assert.Error(t, err, "GenerateName with Male and 0 syllables should return an error")
+
+	_, err = aslanwords.GenerateName(ctx, aslanwords.Female, aslanwords.WithNumberOfSyllables(0))
+	assert.Error(t, err, "GenerateName with Female and 0 syllables should return an error")
+}
+
+func TestGenerate_with_TypeMaleName_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeMaleName should produce a non-empty string")
+}
+
+func TestGenerate_with_TypeFemaleName_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeFemaleName))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeFemaleName should produce a non-empty string")
+}
+
+func TestGenerate_with_TypeWord_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeWord))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeWord should produce a non-empty string")
+}
+
+func TestGenerate_with_TypeMaleName_and_syllables_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName), aslanwords.WithNumberOfSyllables(2))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeMaleName and 2 syllables should produce a non-empty string")
+}
+
+func TestGenerate_with_TypeFemaleName_and_syllables_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeFemaleName), aslanwords.WithNumberOfSyllables(5))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeFemaleName and 5 syllables should produce a non-empty string")
+}
+
+func TestGenerate_with_TypeWord_and_syllables_option(t *testing.T) {
+	ctx := context.Background()
+	name, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeWord), aslanwords.WithNumberOfSyllables(3))
+	require.NoError(t, err)
+	assert.NotEmpty(t, name, "Generate with TypeWord and 3 syllables should produce a non-empty string")
+}
+
+// Test to ensure that providing an invalid combination (though hard with current options) or future validation logic is caught.
+// For now, an invalid WordType is not possible at compile time if using the enum.
+// This test serves as a placeholder if more complex validation rules are added to option combinations.
+func TestGenerate_invalid_options_combination(t *testing.T) {
+	ctx := context.Background()
+		// Test that providing a syllable count that itself is invalid, along with a type, still fails.
+		// These tests now route through Generate -> GenerateName for TypeMaleName/TypeFemaleName
+	_, err := aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeMaleName), aslanwords.WithNumberOfSyllables(0))
+	assert.Error(t, err, "Generate with TypeMaleName and 0 syllables should return an error")
+
+	_, err = aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeFemaleName), aslanwords.WithNumberOfSyllables(0))
+	assert.Error(t, err, "Generate with TypeFemaleName and 0 syllables should return an error")
+
+	_, err = aslanwords.Generate(ctx, aslanwords.WithType(aslanwords.TypeWord), aslanwords.WithNumberOfSyllables(0))
+	assert.Error(t, err, "Generate with TypeWord and 0 syllables should return an error")
+}
+
 func TestGenerate_when_invalid_range_of_syllables_generate_should_return_error(t *testing.T) {
 	ctx := context.Background()
 	_, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllablesBetween(5, 3))

--- a/pkg/aslanwords/opts.go
+++ b/pkg/aslanwords/opts.go
@@ -5,10 +5,47 @@ import (
 	"math/rand"
 )
 
+// WordType defines the type of word to be generated.
+type WordType int
+
+// Gender defines the gender for name generation.
+type Gender int
+
+const (
+	// TypeWord generates a generic Aslan word.
+	TypeWord WordType = iota
+	// TypeMaleName signals generation of an Aslan male name.
+	TypeMaleName
+	// TypeFemaleName signals generation of an Aslan female name.
+	TypeFemaleName
+)
+
+const (
+	// Male specifies male gender for name generation.
+	Male Gender = iota
+	// Female specifies female gender for name generation.
+	Female
+)
+
+// WithType sets the type of word to generate.
+// If the type is TypeMaleName or TypeFemaleName, it also sets the corresponding gender.
+func WithType(wordType WordType) GeneratorOption {
+	return func(o *GeneratorOptions) {
+		o.wordType = wordType
+		switch wordType {
+		case TypeMaleName:
+			o.gender = Male
+		case TypeFemaleName:
+			o.gender = Female
+		}
+	}
+}
+
 // WithNumberOfSyllables sets the number of syllables to generate-word
 func WithNumberOfSyllables(n int) GeneratorOption {
 	return func(o *GeneratorOptions) {
 		o.numberOfSyllablesOpts = fixedAmountOpt{numberOfSyllables: n}
+		o.isSyllableCountUserSet = true
 	}
 }
 
@@ -16,6 +53,7 @@ func WithNumberOfSyllables(n int) GeneratorOption {
 func WithNumberOfSyllablesBetween(from, to int) GeneratorOption {
 	return func(o *GeneratorOptions) {
 		o.numberOfSyllablesOpts = randomAmountOpt{from: from, to: to}
+		o.isSyllableCountUserSet = true
 	}
 }
 
@@ -24,15 +62,24 @@ type GeneratorOption func(*GeneratorOptions)
 
 // GeneratorOptions Options to configure the generation of Aslan words
 type GeneratorOptions struct {
-	numberOfSyllablesOpts amountOptions
+	numberOfSyllablesOpts  amountOptions
+	wordType               WordType
+	isSyllableCountUserSet bool // Tracks if syllable count was explicitly set by the user.
+	gender                 Gender
 }
 
 func newGeneratorOptions() *GeneratorOptions {
 	const defaultMinNumberOfSyllables = 2
 	const defaultMaxNumberOfSyllables = 6
 
-	opts := &GeneratorOptions{}
-	WithNumberOfSyllablesBetween(defaultMinNumberOfSyllables, defaultMaxNumberOfSyllables)(opts)
+	opts := &GeneratorOptions{
+		wordType:               TypeWord, // Default to generating a generic word
+		isSyllableCountUserSet: false,    // Initially false
+		// gender remains its zero value (Male, due to iota) by default,
+		// which is acceptable as it's only explicitly used when wordType indicates a name.
+		// Or, it's explicitly set by WithType or GenerateName.
+	}
+	opts.numberOfSyllablesOpts = randomAmountOpt{from: defaultMinNumberOfSyllables, to: defaultMaxNumberOfSyllables}
 
 	return opts
 }


### PR DESCRIPTION
This commit refactors the Aslan name generation functionality based on your feedback to use a single `GenerateName(gender, opts...)` function.

Key changes:
- Introduced `aslanwords.GenerateName(ctx, gender, opts...)` as the primary function for generating male or female names. This function handles gender-specific logic, including default syllable counts (3-5 for Male, 2-4 for Female) which can be overridden by options.
- The `aslanwords.Gender` enum (`Male`, `Female`) was added for use with `GenerateName`.
- The previous `GenerateMaleName` and `GenerateFemaleName` functions are now deprecated and internally call the new `GenerateName` function to maintain backward compatibility.
- The main `aslanwords.Generate` function, when used with `WithType(TypeMaleName)` or `WithType(TypeFemaleName)`, now also routes its logic through the new `GenerateName` function.
- Tests in `pkg/aslanwords/generate_test.go` have been updated to cover `GenerateName` directly and to confirm deprecated functions still work.
- Examples in `examples/examples.go` and documentation in `README.md` have been updated to reflect `GenerateName` as the recommended approach and to note the deprecated functions.
- CLI functionality remains unchanged for you but benefits from the internal library refactoring.