### PR TITLE
feat: Add Aslan name generation by gender

### DIFF
--- a/cmd/generate-word/main.go
+++ b/cmd/generate-word/main.go
@@ -10,10 +10,25 @@ import (
 )
 
 func main() {
-	opts := readOptionsOrFail()
+	parsedCliOpts := readOptionsOrFail() // Assume this function will be updated in the next step to return an object with a Gender field
 
 	ctx := context.Background()
-	word, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllables(opts.NumberOfSyllables))
+	var word string
+	var err error
+
+	genOpts := []aslanwords.GeneratorOption{}
+	// Assuming NumberOfSyllables will be 0 if not set by the user, or a positive integer if set.
+	// The readOptionsOrFail function would be responsible for this parsing logic.
+	if parsedCliOpts.NumberOfSyllables > 0 {
+		genOpts = append(genOpts, aslanwords.WithNumberOfSyllables(parsedCliOpts.NumberOfSyllables))
+	}
+
+	if parsedCliOpts.Gender != "" {
+		word, err = aslanwords.GenerateName(ctx, parsedCliOpts.Gender, genOpts...)
+	} else {
+		word, err = aslanwords.Generate(ctx, genOpts...)
+	}
+
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/generate-word/main_test.go
+++ b/cmd/generate-word/main_test.go
@@ -4,31 +4,164 @@ import (
 	"io"
 	"os"
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_cmd_should_generate_a_word_when_called_with_n3(t *testing.T) {
-	// Redirect stdout to capture the output
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+// mockExit stores the exit code from os.Exit
+var mockExitCode int
 
-	// Given
-	// the command line arguments are "-n3"
-	os.Args = []string{"path-to-cmd", "-s3"}
+// mockOsExit replaces os.Exit for testing, capturing the exit code.
+func mockOsExit(code int) {
+	mockExitCode = code
+	panic("os.Exit called") // Panic to stop execution like os.Exit would, but allow recovery in test
+}
 
-	// When
-	// Call the main function
-	main()
+// runMainWithArgs executes the main function with given arguments and captures its output and exit code.
+func runMainWithArgs(args []string) (stdoutStr, stderrStr string, exitCode int) {
+	// Reset mockExitCode for each run
+	mockExitCode = 0
 
-	// Restore stdout and read the output
-	w.Close()
-	os.Stdout = old
-	output, err := io.ReadAll(r)
+	oldOsArgs := os.Args
+	oldOsStdout := os.Stdout
+	oldOsStderr := os.Stderr
+	// Store the original osExit and defer its restoration
+	originalOsExit := osExit
+	osExit = mockOsExit // Assign the mock function
+	defer func() {
+		os.Args = oldOsArgs
+		os.Stdout = oldOsStdout
+		os.Stderr = oldOsStderr
+		osExit = originalOsExit // Restore the original os.Exit
+	}()
 
-	// Check the output
-	require.NoError(t, err, "command execution failed with error: %v, output: %s", err, output)
-	assert.Greater(t, len(output), 0, "expected non-empty output, got: %s", output)
+	os.Args = append([]string{"cmd"}, args...) // Prepend command name
+
+	rOut, wOut, _ := os.Pipe()
+	os.Stdout = wOut
+
+	rErr, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+
+	// Recover from panic caused by mockOsExit
+	defer func() {
+		if r := recover(); r != nil {
+			if r != "os.Exit called" {
+				panic(r) // Re-panic if it's not the one from mockOsExit
+			}
+		}
+		exitCode = mockExitCode
+	}()
+
+	main() // Execute the application's main function
+
+	wOut.Close()
+	wErr.Close()
+
+	stdoutBytes, _ := io.ReadAll(rOut)
+	stderrBytes, _ := io.ReadAll(rErr)
+
+	return string(stdoutBytes), string(stderrBytes), mockExitCode
+}
+
+// It's necessary to allow os.Exit to be replaced for testing.
+// This is a common pattern.
+var osExit = os.Exit
+
+func TestMainCLI(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 []string
+		expectedExitCode     int
+		expectedStdoutEmpty  bool // Check if stdout should be empty
+		expectedStderrContains string
+	}{
+		{
+			name:                "no args (default syllables)",
+			args:                []string{}, // Default behavior uses 2 syllables
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                "syllables 3",
+			args:                []string{"-s3"},
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                "gender male",
+			args:                []string{"--gender", "male"},
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                "gender female short flag",
+			args:                []string{"-g", "female"},
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                "gender male syllables 3",
+			args:                []string{"--gender", "male", "--syllables", "3"},
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                "gender female syllables 2",
+			args:                []string{"--gender", "female", "-s", "2"},
+			expectedExitCode:    0,
+			expectedStdoutEmpty: false,
+		},
+		{
+			name:                 "invalid gender",
+			args:                 []string{"--gender", "xyz"},
+			expectedExitCode:     1,
+			expectedStdoutEmpty:  true,
+			expectedStderrContains: "invalid gender: xyz",
+		},
+		{
+			name:                 "gender male syllables 0",
+			args:                 []string{"--gender", "male", "--syllables", "0"},
+			expectedExitCode:     1,
+			expectedStdoutEmpty:  true,
+			expectedStderrContains: "number of syllables must be one or greater",
+		},
+		{
+			name:                 "syllables 0 (no gender)",
+			args:                 []string{"-s0"},
+			expectedExitCode:     1,
+			expectedStdoutEmpty:  true,
+			expectedStderrContains: "number of syllables must be one or greater",
+		},
+		{
+			name:                 "help flag",
+			args:                 []string{"--help"},
+			expectedExitCode:     0, // go-flags exits with 0 on --help
+			expectedStdoutEmpty:  false, // Help message goes to stdout
+			expectedStderrContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runMainWithArgs(tt.args)
+
+			assert.Equal(t, tt.expectedExitCode, exitCode, "unexpected exit code")
+
+			if tt.expectedStdoutEmpty {
+				assert.Empty(t, stdout, "expected stdout to be empty")
+			} else {
+				assert.NotEmpty(t, stdout, "expected stdout to be non-empty")
+			}
+
+			if tt.expectedStderrContains != "" {
+				require.Contains(t, stderr, tt.expectedStderrContains, "stderr does not contain expected message")
+			}
+			// The empty 'else' block that caused a lint error was here. It has been removed.
+			// If tt.expectedStderrContains is empty, no assertion is made on stderr,
+			// allowing for cases where stderr might have non-critical output or be empty.
+		})
+	}
 }

--- a/cmd/generate-word/opts.go
+++ b/cmd/generate-word/opts.go
@@ -7,7 +7,8 @@ import (
 )
 
 type commandOptions struct {
-	NumberOfSyllables int `short:"s" default:"2" long:"number-of-syllables" description:"Number of syllables of the aslan word to generate"`
+	NumberOfSyllables int    `short:"s" default:"2" long:"number-of-syllables" description:"Number of syllables of the aslan word to generate"`
+	Gender            string `short:"g" long:"gender" description:"Specify gender for name generation (male or female)"`
 }
 
 func readOptionsOrFail() commandOptions {

--- a/pkg/aslanwords/generate.go
+++ b/pkg/aslanwords/generate.go
@@ -40,3 +40,90 @@ func MustGenerate(ctx context.Context, opts ...GeneratorOption) string {
 	}
 	return word
 }
+
+// generateNameSyllablesWereSetByUser checks if the user's options would alter the default syllable count.
+func generateNameSyllablesWereSetByUser(passedOpts ...GeneratorOption) bool {
+	if len(passedOpts) == 0 {
+		return false
+	}
+
+	defaultSyllableConfig := newGeneratorOptions().numberOfSyllablesOpts
+	
+	optsApplied := newGeneratorOptions()
+	for _, o := range passedOpts {
+		o(optsApplied)
+	}
+	effectiveSyllableConfig := optsApplied.numberOfSyllablesOpts
+
+	// Compare by type and value.
+	// Default is randomAmountOpt{from: 2, to: 6}
+	defaultRandom, okDefault := defaultSyllableConfig.(randomAmountOpt)
+	effectiveRandom, okEffectiveRandom := effectiveSyllableConfig.(randomAmountOpt)
+	_, okEffectiveFixed := effectiveSyllableConfig.(fixedAmountOpt)
+
+	if okEffectiveFixed {
+		return true // User explicitly set a fixed number.
+	}
+
+	if okDefault && okEffectiveRandom {
+		// Both are random; if values differ, user set them.
+		if defaultRandom.from == effectiveRandom.from && defaultRandom.to == effectiveRandom.to {
+			return false // Same as default random range.
+		}
+		return true // Different random range.
+	}
+	
+	// If types are different and not handled above (e.g. default is random, effective is something else entirely)
+	// This would imply a custom amountOptions was introduced, or it's fixed (already handled).
+	// If effective is still random but default wasn't (hypothetically), it's also a change.
+	// For this function, if it's not fixed and not a different random, assume it wasn't explicitly set to override default.
+	if !okDefault && okEffectiveRandom { // Should not happen if newGeneratorOptions is consistent
+		return true
+	}
+
+	return false // If it's still the default random config, or len(opts) == 0
+}
+
+
+// GenerateName generates a random Aslan name based on gender and options.
+func GenerateName(ctx context.Context, gender string, opts ...GeneratorOption) (string, error) {
+	options := newGeneratorOptions() // Base options with library defaults (e.g., 2-6 syllables)
+
+	// Determine if user options include specific syllable settings
+	syllablesSetByPassedOpts := generateNameSyllablesWereSetByUser(opts...)
+
+	// Apply all passed options to the main 'options' object
+	for _, o := range opts {
+		o(options)
+	}
+
+	if gender != "male" && gender != "female" {
+		return "", fmt.Errorf("invalid gender: %s, must be 'male' or 'female'", gender)
+	}
+
+	// If user options did not specify syllable count, apply gender-based defaults.
+	if !syllablesSetByPassedOpts {
+		if gender == "male" {
+			WithNumberOfSyllablesBetween(3, 4)(options) // Modifies 'options' in place
+		} else if gender == "female" { // "female"
+			WithNumberOfSyllablesBetween(2, 3)(options) // Modifies 'options' in place
+		}
+	}
+
+	err := options.Validate()
+	if err != nil {
+		return "", fmt.Errorf("invalid options: %w", err)
+	}
+
+	wordTemplate := syllable.GenerateTemplate(options.numberOfSyllables())
+	gen, err := fantasyname.Compile(wordTemplate.String(), fantasyname.Collapse(true), fantasyname.RandFn(rand.Intn))
+	if err != nil {
+		return "", fmt.Errorf("unexpected error generating the aslan name: %w", err)
+	}
+	return gen.String(), nil
+}
+
+// All subsequent function definitions were identified as duplicates
+// from previous patching attempts and have been removed.
+// The correct versions of generateNameSyllablesWereSetByUser (lines 43-78)
+// and GenerateName (lines 81-125) are preserved above.

--- a/pkg/aslanwords/generate_test.go
+++ b/pkg/aslanwords/generate_test.go
@@ -36,6 +36,112 @@ func TestGenerate_when_asked_to_generate_word_with_less_than_one_syllables_shoul
 	assert.Error(t, err)
 }
 
+func TestGenerateName(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		gender        string
+		opts          []aslanwords.GeneratorOption
+		wantErr       bool
+		errorContains string
+	}{
+		{
+			name:    "male name generation default syllables",
+			gender:  "male",
+			opts:    nil,
+			wantErr: false,
+		},
+		{
+			name:   "male name generation with 3 syllables",
+			gender: "male",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(3),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "male name generation with 1 syllable",
+			gender: "male",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(1),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "female name generation default syllables",
+			gender:  "female",
+			opts:    nil,
+			wantErr: false,
+		},
+		{
+			name:   "female name generation with 2 syllables",
+			gender: "female",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(2),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "female name generation with 1 syllable",
+			gender: "female",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(1),
+			},
+			wantErr: false,
+		},
+		{
+			name:          "invalid gender unknown",
+			gender:        "unknown",
+			opts:          nil,
+			wantErr:       true,
+			errorContains: "invalid gender: unknown",
+		},
+		{
+			name:          "invalid gender empty",
+			gender:        "",
+			opts:          nil,
+			wantErr:       true,
+			errorContains: "invalid gender: ",
+		},
+		{
+			name:   "male name generation with 0 syllables (error case)",
+			gender: "male",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(0),
+			},
+			wantErr:       true,
+			errorContains: "number of syllables must be one or greater",
+		},
+		{
+			name:   "female name generation with 0 syllables (error case)",
+			gender: "female",
+			opts: []aslanwords.GeneratorOption{
+				aslanwords.WithNumberOfSyllables(0),
+			},
+			wantErr:       true,
+			errorContains: "number of syllables must be one or greater",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, err := aslanwords.GenerateName(ctx, tt.gender, tt.opts...)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, name)
+				// Verifying exact syllable counts is complex and depends on the fantasyname library.
+				// For now, we ensure a name is generated.
+			}
+		})
+	}
+}
+
 func TestGenerate_when_invalid_range_of_syllables_generate_should_return_error(t *testing.T) {
 	ctx := context.Background()
 	_, err := aslanwords.Generate(ctx, aslanwords.WithNumberOfSyllablesBetween(5, 3))


### PR DESCRIPTION
Adds a new function `GenerateName` to the `aslanwords` package and updates the CLI to support generating Aslan-style names based on gender.

The `GenerateName` function allows specifying "male" or "female" gender. If no syllable count is provided by you, it defaults to 3-4 syllables for male names and 2-3 syllables for female names. These patterns are based on common fantasy naming conventions due to limitations in researching specific Aslan linguistic rules.

The CLI tool `generate-word` now includes a `--gender` (or `-g`) flag to use this new functionality. If the flag is not provided, the tool behaves as before, generating a generic Aslan word.

Unit tests have been added for the new library function and the CLI updates, covering various scenarios including valid inputs, invalid inputs, and default behaviors. All linters pass.